### PR TITLE
use "throw ..." instead of "Write-Error ...; Exit 1"

### DIFF
--- a/psperl.ps1
+++ b/psperl.ps1
@@ -13,8 +13,7 @@ param (
 # Make sure we only attempt to work for PowerShell v5 and greater
 # this allows the use of classes.
 if ($PSVersionTable.PSVersion.Major -lt 5) {
-    Write-Error "PowerShell v5.0+ is required for psperl. https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell?view=powershell-6";
-    exit
+    throw "PowerShell v5.0+ is required for psperl. https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell?view=powershell-6";
 }
 $psperl_path = (Split-Path -parent $MyInvocation.MyCommand.Definition);
 $env:PSPERL_ROOT = $psperl_path;
@@ -98,16 +97,14 @@ elseif ($install) {
 
     # if nothing is found, a null thingy is returned. This can be tested with a simple truthiness test
     if (-Not $found) {
-        Write-Error("No installable version of Perl found by the name $($install). Try `psperl -available` to get a list of available perl installations.");
-        exit(1);
+        throw "No installable version of Perl found by the name $($install). Try `"psperl -available`" to get a list of available perl installations.";
     }
     # check to see if we got just one.
     if ($found -is 'System.Object') {
         $psperl.Install($found);
     }
     else {
-        Write-Error("Unexpected results $($found.GetType()) searching for $($install). Try `psperl -available` to get a list of available perl installations.");
-        exit(1);
+        throw "Unexpected results `"$($found.GetType())`" searching for `"$($install)`". Try `"psperl -available`" to get a list of available perl installations.";
     }
 }
 elseif ($switch) { $psperl.Use($switch, $true); }

--- a/src/PSPerl.ps1
+++ b/src/PSPerl.ps1
@@ -7,8 +7,7 @@ class PSPerl {
     # Constructor
     PSPerl([string]$rootPath, [string]$profilePath) {
         if(![System.IO.Directory]::Exists($rootPath)) {
-            Write-Error "Invalid root path provided";
-            exit(1);
+            throw "Invalid root path provided";
         }
         $this.URL = 'http://strawberryperl.com/releases.json';
         $this.rootPath = $rootPath;
@@ -22,8 +21,7 @@ class PSPerl {
         $the_bits = (Get-CimInstance Win32_OperatingSystem).OSArchitecture;
         if ($the_bits -eq '64-bit') { return 64; }
         elseif ($the_bits -eq '32-bit') { return 32; }
-        Write-Error("Invalid OS Architecture? We don't know what to do with a $($the_bits)-bit architecture");
-        exit(1);
+        throw "Invalid OS Architecture? We don't know what to do with a `"$($the_bits)`" architecture";
     }
 
     # return the current PowerShell's bitness. will be 64 or 32. might not be the same as the OS
@@ -31,8 +29,7 @@ class PSPerl {
         $the_bits = [System.Runtime.InterOpServices.Marshal]::SizeOf([System.IntPtr]::Zero)*8;
         if ($the_bits -eq '64') { return 64; }
         elseif ($the_bits -eq '32') { return 32; }
-        Write-Error("Invalid PowerShell Architecture? We don't know what to do with a $($the_bits)-bit PowerShell");
-        exit(1);
+        throw "Invalid PowerShell Architecture? We don't know what to do with a $($the_bits)-bit PowerShell";
     }
 
     # get an array of available Portable Perl versions
@@ -148,21 +145,18 @@ class PSPerl {
             # check to make sure we got the right size file
             [int]$size = (Get-Item $pathZip).length;
             if ($size -ne $perl_obj.size) {
-                Write-Error("The file we have is $($size) bytes but we expected $($perl_obj.size). Deleting the file.");
                 Remove-Item -Path $pathZip -Force;
-                exit(1);
+                throw "The file we have is $($size) bytes but we expected $($perl_obj.size). Deleting the file.";
             }
             # check the SHA1 checksums
             [String]$checksum = (Get-FileHash -Path $pathZip -Algorithm SHA1).hash;
             if ($checksum -ne $perl_obj.sha1) {
-                Write-Error("The file's SHA1 checksum is off. Deleting the file.");
                 Remove-Item -Path $pathZip -Force;
-                exit(1);
+                throw "The file's SHA1 checksum is off. Deleting the file.";
             }
         }
         else {
-            Write-Error("We tried to download the file, but we didn't get it.");
-            exit(1);
+            throw "We tried to download the file, but we didn't get it.";
         }
 
         # extract the zip into the directory
@@ -252,8 +246,7 @@ class PSPerl {
 
     [void] Use([string]$perl_install, [bool]$persistent = $false) {
         if (-Not $this.InstalledPerls().Contains($perl_install)) {
-            Write-Error("$($perl_install) isn't yet installed. Try installing it.");
-            exit(1);
+            throw "$($perl_install) isn't yet installed. Try installing it.";
         }
         $this.ClearEnvironment();
         $env:PATH = "$($this.rootPath);$($env:PATH)";


### PR DESCRIPTION
Write-Error is (almost) a no-op inside methods. It currently works
inside void methods but it's a bug, not an intentional feature.

See PowerShell/PowerShell#5331 and PowerShell/PowerShell#9702

Also, "throw" is more correct semantically.